### PR TITLE
Roughly update the list of languages to upstream linguist.

### DIFF
--- a/lib/language_sniffer/blob_helper.rb
+++ b/lib/language_sniffer/blob_helper.rb
@@ -1,3 +1,4 @@
+# encoding: UTF-8
 require 'language_sniffer/language'
 require 'language_sniffer/pathname'
 require 'yaml'
@@ -225,6 +226,24 @@ module LanguageSniffer
       end
     end
 
+    # Internal: Guess language of .cls files
+    #
+    # Returns a Language.
+    def guess_cls_language
+      if lines.grep(/^(%|\\)/).any?
+        Language['TeX']
+      elsif lines.grep(/^\s*(CLASS|METHOD|INTERFACE).*:\s*/i).any? || lines.grep(/^\s*(USING|DEFINE)/i).any?
+        Language['OpenEdge ABL']
+      elsif lines.grep(/\{$/).any? || lines.grep(/\}$/).any?
+        Language['Apex']
+      elsif lines.grep(/^(\'\*|Attribute|Option|Sub|Private|Protected|Public|Friend)/i).any?
+        Language['Visual Basic']
+      else
+        # The most common language should be the fallback
+        Language['TeX']
+      end
+    end
+
     # Internal: Guess language of header files (.h).
     #
     # Returns a Language.
@@ -294,6 +313,39 @@ module LanguageSniffer
         Language['Rebol']
       else
         Language['R']
+      end
+    end
+
+    # Internal: Guess language of .t files.
+    #
+    # Returns a Language.
+    def guess_t_language
+      score = 0
+      score += 1 if lines.grep(/^% /).any?
+      score += data.gsub(/ := /).count
+      score += data.gsub(/proc |procedure |fcn |function /).count
+      score += data.gsub(/var \w+: \w+/).count
+
+      # Tell-tale signs its gotta be Perl
+      if lines.grep(/^(my )?(sub |\$|@|%)\w+/).any?
+        score = 0
+      end
+
+      if score >= 3
+        Language['Turing']
+      else
+        Language['Perl']
+      end
+    end
+
+    # Internal: Guess language of .v files.
+    #
+    # Returns a Language
+    def guess_v_language
+      if lines.grep(/^(\/\*|\/\/|module|parameter|input|output|wire|reg|always|initial|begin|\`)/).any?
+        Language['Verilog']
+      else
+        Language['Coq']
       end
     end
 

--- a/lib/language_sniffer/languages.yml
+++ b/lib/language_sniffer/languages.yml
@@ -26,7 +26,6 @@
 
 ASP:
   type: programming
-  color: "#6a40fd"
   lexer: aspx-vb
   search_term: aspx-vb
   aliases:
@@ -45,7 +44,6 @@ ASP:
 ActionScript:
   type: programming
   lexer: ActionScript 3
-  color: "#e3491a"
   search_term: as3
   aliases:
   - as3
@@ -54,7 +52,6 @@ ActionScript:
 
 Ada:
   type: programming
-  color: "#02f88c"
   extensions:
   - .adb
   - .ads
@@ -75,14 +72,12 @@ AppleScript:
 
 Arc:
   type: programming
-  color: "#ca2afe"
   lexer: Text only
   extensions:
   - .arc
 
 Arduino:
   type: programming
-  color: "#bd79d1"
   lexer: C++
   extensions:
   - .ino
@@ -90,7 +85,6 @@ Arduino:
 Assembly:
   type: programming
   lexer: NASM
-  color: "#a67219"
   search_term: nasm
   aliases:
   - nasm
@@ -105,7 +99,6 @@ Augeas:
 AutoHotkey:
   type: programming
   lexer: autohotkey
-  color: "#6594b9"
   aliases:
   - ahk
   extensions:
@@ -132,7 +125,6 @@ BlitzMax:
 
 Boo:
   type: programming
-  color: "#d4bec1"
   extensions:
   - .boo
 
@@ -148,7 +140,6 @@ Bro:
 
 C:
   type: programming
-  color: "#555"
   overrides:
   - .h
   primary_extension: .c
@@ -161,7 +152,6 @@ C#:
   type: programming
   ace_mode: csharp
   search_term: csharp
-  color: "#5a25a2"
   aliases:
   - csharp
   extensions:
@@ -171,7 +161,6 @@ C++:
   type: programming
   ace_mode: c_cpp
   search_term: cpp
-  color: "#f34b7d"
   aliases:
   - cpp
   primary_extension: .cpp
@@ -223,7 +212,6 @@ ChucK:
 Clojure:
   type: programming
   ace_mode: clojure
-  color: "#db5855"
   primary_extension: .clj
   extensions:
   - .clj
@@ -232,7 +220,6 @@ Clojure:
 CoffeeScript:
   type: programming
   ace_mode: coffee
-  color: "#244776"
   aliases:
   - coffee
   extensions:
@@ -244,7 +231,6 @@ ColdFusion:
   type: programming
   lexer: Coldfusion HTML
   ace_mode: coldfusion
-  color: "#ed2cd6"
   search_term: cfm
   aliases:
   - cfm
@@ -255,7 +241,6 @@ ColdFusion:
 
 Common Lisp:
   type: programming
-  color: "#3fb68b"
   aliases:
   - lisp
   primary_extension: .lisp
@@ -293,7 +278,6 @@ Cython:
 
 D:
   type: programming
-  color: "#fcd46d"
   extensions:
   - .d
   - .di
@@ -319,7 +303,6 @@ Dart:
 
 Delphi:
   type: programming
-  color: "#b0ce4e"
   primary_extension: .pas
   extensions:
   - .dpr
@@ -343,7 +326,6 @@ Diff:
 
 Dylan:
   type: programming
-  color: "#3ebc27"
   extensions:
   - .dylan
 
@@ -357,13 +339,11 @@ Ecere Projects:
 Eiffel:
   type: programming
   lexer: Text only
-  color: "#946d57"
   extensions:
   - .e
 
 Elixir:
   type: programming
-  color: "#6e4a7e"
   primary_extension: .ex
   extensions:
   - .ex
@@ -372,7 +352,6 @@ Elixir:
 Emacs Lisp:
   type: programming
   lexer: Scheme
-  color: "#c065db"
   aliases:
   - elisp
   - emacs
@@ -383,7 +362,6 @@ Emacs Lisp:
 
 Erlang:
   type: programming
-  color: "#949e0e"
   primary_extension: .erl
   extensions:
   - .erl
@@ -392,7 +370,6 @@ Erlang:
 F#:
   type: programming
   lexer: FSharp
-  color: "#b845fc"
   search_term: ocaml
   extensions:
   - .fs
@@ -402,7 +379,6 @@ F#:
 FORTRAN:
   type: programming
   lexer: Fortran
-  color: "#4d41b1"
   primary_extension: .f90
   extensions:
   - .F
@@ -424,13 +400,11 @@ FORTRAN:
 
 Factor:
   type: programming
-  color: "#636746"
   extensions:
   - .factor
 
 Fancy:
   type: programming
-  color: "#7b9db4"
   primary_extension: .fy
   extensions:
   - .fancypack
@@ -438,7 +412,6 @@ Fancy:
 
 Fantom:
   type: programming
-  color: "#dbded5"
   extensions:
   - .fan
 
@@ -477,13 +450,11 @@ Gettext Catalog:
 
 Go:
   type: programming
-  color: "#8d04eb"
   extensions:
   - .go
 
 Gosu:
   type: programming
-  color: "#82937f"
   primary_extension: .gs
   extensions:
   - .gs
@@ -507,7 +478,6 @@ Groff:
 Groovy:
   type: programming
   ace_mode: groovy
-  color: "#e69f56"
   primary_extension: .groovy
   extensions:
   - .gradle
@@ -559,7 +529,6 @@ HaXe:
   type: programming
   lexer: haXe
   ace_mode: haxe
-  color: "#346d51"
   extensions:
   - .hx
   - .hxml
@@ -573,7 +542,6 @@ Haml:
 
 Haskell:
   type: programming
-  color: "#29b544"
   extensions:
   - .hs
   - .hsc
@@ -598,13 +566,11 @@ IRC log:
 
 Io:
   type: programming
-  color: "#a9188d"
   extensions:
   - .io
 
 Ioke:
   type: programming
-  color: "#078193"
   extensions:
   - .ik
 
@@ -619,7 +585,6 @@ JSON:
 Java:
   type: programming
   ace_mode: java
-  color: "#b07219"
   extensions:
   - .java
   - .pde
@@ -636,7 +601,6 @@ Java Server Pages:
 JavaScript:
   type: programming
   ace_mode: javascript
-  color: "#f15501"
   aliases:
   - js
   - node
@@ -695,7 +659,6 @@ Logtalk:
 Lua:
   type: programming
   ace_mode: lua
-  color: "#fa1fa1"
   extensions:
   - .lua
   - .nse
@@ -728,7 +691,6 @@ Markdown:
 
 Matlab:
   type: programming
-  color: "#bb92ac"
   primary_extension: .matlab
   extensions:
   - .m
@@ -736,7 +698,6 @@ Matlab:
 
 Max/MSP:
   type: programming
-  color: "#ce279c"
   lexer: Text only
   extensions:
   - .mxt
@@ -749,7 +710,6 @@ Mirah:
   type: programming
   lexer: Ruby
   search_term: ruby
-  color: "#c7a938"
   extensions:
   - .duby
   - .mir
@@ -766,13 +726,11 @@ Myghty:
 
 Nemerle:
   type: programming
-  color: "#0d3c6e"
   extensions:
   - .n
 
 Nimrod:
   type: programming
-  color: "#37775b"
   extensions:
   - .nim
   - .nimrod
@@ -780,7 +738,6 @@ Nimrod:
 Nu:
   type: programming
   lexer: Scheme
-  color: "#c9df40"
   aliases:
   - nush
   extensions:
@@ -799,7 +756,6 @@ NumPy:
 OCaml:
   type: programming
   ace_mode: ocaml
-  color: "#3be133"
   primary_extension: .ml
   extensions:
   - .ml
@@ -815,7 +771,6 @@ ObjDump:
 
 Objective-C:
   type: programming
-  color: "#438eff"
   overrides:
   - .m
   primary_extension: .m
@@ -826,7 +781,6 @@ Objective-C:
 
 Objective-J:
   type: programming
-  color: "#ff0c5a"
   extensions:
   - .j
   - .sj
@@ -857,7 +811,6 @@ OpenEdge ABL:
 PHP:
   type: programming
   ace_mode: php
-  color: "#6e03c1"
   extensions:
   - .aw
   - .ctp
@@ -871,7 +824,6 @@ PHP:
 
 Parrot:
   type: programming
-  color: "#f3ca0a"
   lexer: Text only
   primary_extension: .parrot # Dummy extension
 
@@ -896,7 +848,6 @@ Parrot Assembly:
 Perl:
   type: programming
   ace_mode: perl
-  color: "#0298c3"
   overrides:
   - .pl
   - .t
@@ -923,7 +874,6 @@ PowerShell:
 
 Prolog:
   type: programming
-  color: "#74283c"
   extensions:
   - .pl
   - .pro
@@ -931,7 +881,6 @@ Prolog:
 
 Puppet:
   type: programming
-  color: "#cc5555"
   extensions:
   - .pp
   filenames:
@@ -939,7 +888,6 @@ Puppet:
 
 Pure Data:
   type: programming
-  color: "#91de79"
   lexer: Text only
   extensions:
   - .pd
@@ -947,7 +895,6 @@ Pure Data:
 Python:
   type: programming
   ace_mode: python
-  color: "#3581ba"
   primary_extension: .py
   extensions:
   - .py
@@ -965,7 +912,6 @@ Python traceback:
 
 R:
   type: programming
-  color: "#198ce7"
   lexer: S
   overrides:
   - .r
@@ -983,7 +929,6 @@ RHTML:
 Racket:
   type: programming
   lexer: Scheme
-  color: "#ae17ff"
   primary_extension: .rkt
   extensions:
   - .rkt
@@ -1001,7 +946,6 @@ Raw token data:
 Rebol:
   type: programming
   lexer: REBOL
-  color: "#358a5b"
   extensions:
   - .r
   - .r2
@@ -1015,7 +959,6 @@ Redcode:
 Ruby:
   type: programming
   ace_mode: ruby
-  color: "#701516"
   aliases:
   - jruby
   - macruby
@@ -1048,7 +991,6 @@ Ruby:
 
 Rust:
   type: programming
-  color: "#dea584"
   lexer: Text only
   extensions:
   - .rs
@@ -1083,7 +1025,6 @@ Sass:
 Scala:
   type: programming
   ace_mode: scala
-  color: "#7dd3b0"
   primary_extension: .scala
   extensions:
   - .sbt
@@ -1091,7 +1032,6 @@ Scala:
 
 Scheme:
   type: programming
-  color: "#1e4aec"
   primary_extension: .scm
   extensions:
   - .scm
@@ -1108,7 +1048,6 @@ Scilab:
 
 Self:
   type: programming
-  color: "#0579aa"
   lexer: Text only
   extensions:
   - .self
@@ -1117,7 +1056,6 @@ Shell:
   type: programming
   lexer: Bash
   search_term: bash
-  color: "#5861ce"
   aliases:
   - sh
   - bash
@@ -1139,7 +1077,6 @@ Shell:
 
 Smalltalk:
   type: programming
-  color: "#596706"
   extensions:
   - .st
 
@@ -1149,7 +1086,6 @@ Smarty:
 
 Standard ML:
   type: programming
-  color: "#dc566d"
   aliases:
   - sml
   primary_extension: .sml
@@ -1159,14 +1095,12 @@ Standard ML:
 
 SuperCollider:
   type: programming
-  color: "#46390b"
   lexer: Text only
   extensions:
   - .sc
 
 Tcl:
   type: programming
-  color: "#e4cc98"
   extensions:
   - .tcl
 
@@ -1215,7 +1149,6 @@ Textile:
 
 Turing:
   type: programming
-  color: "#45f715"
   lexer: Text only
   extensions:
   - .t
@@ -1231,14 +1164,12 @@ Twig:
 VHDL:
   type: programming
   lexer: vhdl
-  color: "#543978"
   extensions:
   - .vhd
   - .vhdl
 
 Vala:
   type: programming
-  color: "#ee7d06"
   extensions:
   - .vala
   - .vapi
@@ -1246,7 +1177,6 @@ Vala:
 Verilog:
   type: programming
   lexer: Verilog
-  color: "#848bf3"
   overrides:
   - .v
   extensions:
@@ -1254,7 +1184,6 @@ Verilog:
 
 VimL:
   type: programming
-  color: "#199c4b"
   search_term: vim
   aliases:
   - vim
@@ -1269,7 +1198,6 @@ VimL:
 Visual Basic:
   type: programming
   lexer: VB.net
-  color: "#945db7"
   primary_extension: .vb
   extensions:
   - .bas
@@ -1307,7 +1235,6 @@ XML:
 
 XQuery:
   type: programming
-  color: "#2700e2"
   extensions:
   - .xq
   - .xqm
@@ -1344,7 +1271,6 @@ mupad:
 ooc:
   type: programming
   lexer: Ooc
-  color: "#b0b77e"
   extensions:
   - .ooc
 

--- a/lib/language_sniffer/languages.yml
+++ b/lib/language_sniffer/languages.yml
@@ -1,8 +1,15 @@
 # Defines all Languages known
 #
+# All languages have an associated lexer for syntax highlighting. It
+# defaults to name.downcase, which covers most cases. Make sure the
+# lexer exists in lexers.yml. This is a list of available in our
+# version of pygments.
+#
 # type              - Either data, programming, markup, or nil
+# lexer             - An explicit lexer String (defaults to name.downcase)
 # aliases           - An Array of additional aliases (implicitly
 #                     includes name.downcase)
+# ace_mode          - A String name of Ace Mode (if available)
 # extension         - An Array of associated extensions
 # primary_extension - A String for the main extension associated with
 #                     the langauge. (defaults to extensions.first)
@@ -10,6 +17,7 @@
 # searchable        - Boolean flag to enable searching (defaults to true)
 # search_term       - Deprecated: Some languages maybe indexed under a
 #                     different alias. Avoid defining new exceptions.
+# color             - CSS hex color to represent the language.
 #
 # Any additions or modifications (even trivial) should have corresponding
 # test change in `test/test_blob.rb`.
@@ -18,6 +26,7 @@
 
 ASP:
   type: programming
+  color: "#6a40fd"
   lexer: aspx-vb
   search_term: aspx-vb
   aliases:
@@ -36,6 +45,7 @@ ASP:
 ActionScript:
   type: programming
   lexer: ActionScript 3
+  color: "#e3491a"
   search_term: as3
   aliases:
   - as3
@@ -44,11 +54,20 @@ ActionScript:
 
 Ada:
   type: programming
+  color: "#02f88c"
   extensions:
   - .adb
   - .ads
 
+Apex:
+  type: programming
+  lexer: Text only
+  extensions:
+  - .cls
+
 AppleScript:
+  aliases:
+  - osascript
   primary_extension: .scpt
   extensions:
   - .applescript
@@ -56,22 +75,37 @@ AppleScript:
 
 Arc:
   type: programming
+  color: "#ca2afe"
   lexer: Text only
   extensions:
   - .arc
 
+Arduino:
+  type: programming
+  color: "#bd79d1"
+  lexer: C++
+  extensions:
+  - .ino
+
 Assembly:
   type: programming
   lexer: NASM
+  color: "#a67219"
   search_term: nasm
   aliases:
   - nasm
   extensions:
   - .asm
 
+Augeas:
+  type: programming
+  extensions:
+  - .aug
+
 AutoHotkey:
   type: programming
   lexer: autohotkey
+  color: "#6594b9"
   aliases:
   - ahk
   extensions:
@@ -98,6 +132,7 @@ BlitzMax:
 
 Boo:
   type: programming
+  color: "#d4bec1"
   extensions:
   - .boo
 
@@ -106,18 +141,27 @@ Brainfuck:
   - .b
   - .bf
 
+Bro:
+  type: programming
+  extensions:
+  - .bro
+
 C:
   type: programming
+  color: "#555"
   overrides:
   - .h
   primary_extension: .c
   extensions:
   - .c
   - .h
+  - .w
 
 C#:
   type: programming
+  ace_mode: csharp
   search_term: csharp
+  color: "#5a25a2"
   aliases:
   - csharp
   extensions:
@@ -125,7 +169,9 @@ C#:
 
 C++:
   type: programming
+  ace_mode: c_cpp
   search_term: cpp
+  color: "#f34b7d"
   aliases:
   - cpp
   primary_extension: .cpp
@@ -148,6 +194,15 @@ C-ObjDump:
   extensions:
   - .c-objdump
 
+C2hs Haskell:
+  type: programming
+  lexer: Haskell
+  group: Haskell
+  aliases:
+  - c2hs
+  extensions:
+  - .chs
+
 CMake:
   extensions:
   - .cmake
@@ -156,6 +211,7 @@ CMake:
   - CMakeLists.txt
 
 CSS:
+  ace_mode: css
   extensions:
   - .css
 
@@ -166,6 +222,8 @@ ChucK:
 
 Clojure:
   type: programming
+  ace_mode: clojure
+  color: "#db5855"
   primary_extension: .clj
   extensions:
   - .clj
@@ -173,6 +231,8 @@ Clojure:
 
 CoffeeScript:
   type: programming
+  ace_mode: coffee
+  color: "#244776"
   aliases:
   - coffee
   extensions:
@@ -183,6 +243,8 @@ CoffeeScript:
 ColdFusion:
   type: programming
   lexer: Coldfusion HTML
+  ace_mode: coldfusion
+  color: "#ed2cd6"
   search_term: cfm
   aliases:
   - cfm
@@ -193,12 +255,19 @@ ColdFusion:
 
 Common Lisp:
   type: programming
+  color: "#3fb68b"
   aliases:
   - lisp
   primary_extension: .lisp
   extensions:
   - .lisp
+  - .lsp
   - .ny
+
+Coq:
+  type: programming
+  extensions:
+  - .v
 
 Cpp-ObjDump:
   type: data
@@ -224,6 +293,7 @@ Cython:
 
 D:
   type: programming
+  color: "#fcd46d"
   extensions:
   - .d
   - .di
@@ -242,12 +312,29 @@ Darcs Patch:
   - .darcspatch
   - .dpatch
 
+Dart:
+  type: programming
+  extensions:
+  - .dart
+
 Delphi:
   type: programming
+  color: "#b0ce4e"
   primary_extension: .pas
   extensions:
   - .dpr
+  - .lpr
   - .pas
+
+DCPU-16 ASM:
+  type: programming
+  lexer: dasm16
+  primary_extension: .dasm16
+  extensions:
+  - .dasm
+  - .dasm16
+  aliases:
+  - dasm16
 
 Diff:
   extensions:
@@ -256,20 +343,39 @@ Diff:
 
 Dylan:
   type: programming
+  color: "#3ebc27"
   extensions:
   - .dylan
+
+Ecere Projects:
+  type: data
+  group: JavaScript
+  lexer: JSON
+  extensions:
+  - .epj
 
 Eiffel:
   type: programming
   lexer: Text only
+  color: "#946d57"
   extensions:
   - .e
+
+Elixir:
+  type: programming
+  color: "#6e4a7e"
+  primary_extension: .ex
+  extensions:
+  - .ex
+  - .exs
 
 Emacs Lisp:
   type: programming
   lexer: Scheme
+  color: "#c065db"
   aliases:
   - elisp
+  - emacs
   primary_extension: .el
   extensions:
   - .el
@@ -277,6 +383,7 @@ Emacs Lisp:
 
 Erlang:
   type: programming
+  color: "#949e0e"
   primary_extension: .erl
   extensions:
   - .erl
@@ -284,7 +391,8 @@ Erlang:
 
 F#:
   type: programming
-  lexer: OCaml
+  lexer: FSharp
+  color: "#b845fc"
   search_term: ocaml
   extensions:
   - .fs
@@ -294,24 +402,45 @@ F#:
 FORTRAN:
   type: programming
   lexer: Fortran
+  color: "#4d41b1"
   primary_extension: .f90
   extensions:
   - .F
+  - .F03
+  - .F08
+  - .F77
   - .F90
+  - .F95
+  - .FOR
+  - .FPP
   - .f
+  - .f03
+  - .f08
+  - .f77
   - .f90
+  - .f95
+  - .for
+  - .fpp
 
 Factor:
   type: programming
+  color: "#636746"
   extensions:
   - .factor
 
 Fancy:
   type: programming
+  color: "#7b9db4"
   primary_extension: .fy
   extensions:
   - .fancypack
   - .fy
+
+Fantom:
+  type: programming
+  color: "#dbded5"
+  extensions:
+  - .fan
 
 GAS:
   type: programming
@@ -348,11 +477,13 @@ Gettext Catalog:
 
 Go:
   type: programming
+  color: "#8d04eb"
   extensions:
   - .go
 
 Gosu:
   type: programming
+  color: "#82937f"
   primary_extension: .gs
   extensions:
   - .gs
@@ -375,7 +506,8 @@ Groff:
 
 Groovy:
   type: programming
-  lexer: Java
+  ace_mode: groovy
+  color: "#e69f56"
   primary_extension: .groovy
   extensions:
   - .gradle
@@ -393,6 +525,7 @@ Groovy Server Pages:
 
 HTML:
   type: markup
+  ace_mode: html
   primary_extension: .html
   extensions:
   - .htm
@@ -425,6 +558,8 @@ HTML+PHP:
 HaXe:
   type: programming
   lexer: haXe
+  ace_mode: haxe
+  color: "#346d51"
   extensions:
   - .hx
   - .hxml
@@ -438,6 +573,7 @@ Haml:
 
 Haskell:
   type: programming
+  color: "#29b544"
   extensions:
   - .hs
   - .hsc
@@ -462,24 +598,28 @@ IRC log:
 
 Io:
   type: programming
+  color: "#a9188d"
   extensions:
   - .io
 
 Ioke:
   type: programming
+  color: "#078193"
   extensions:
   - .ik
 
 JSON:
   type: data
   group: JavaScript
-  lexer: JavaScript
+  ace_mode: json
   searchable: false
   extensions:
   - .json
 
 Java:
   type: programming
+  ace_mode: java
+  color: "#b07219"
   extensions:
   - .java
   - .pde
@@ -495,13 +635,17 @@ Java Server Pages:
 
 JavaScript:
   type: programming
+  ace_mode: javascript
+  color: "#f15501"
   aliases:
   - js
   - node
   primary_extension: .js
   extensions:
+  - .bones
   - .jake
   - .js
+  - .jsfl
   - .jsm
   - .jss
   - .jsx
@@ -510,6 +654,18 @@ JavaScript:
   - .ssjs
   filenames:
   - Jakefile
+
+Julia:
+  type: programming
+  extensions:
+  - .jl
+
+Kotlin:
+  type: programming
+  extensions:
+  - .kt
+  - .ktm
+  - .kts
 
 LLVM:
   extensions:
@@ -531,9 +687,15 @@ Literate Haskell:
   extensions:
   - .lhs
 
+Logtalk:
+  type: programming
+  extensions:
+  - .lgt
+
 Lua:
   type: programming
-  primary_extension: .lua
+  ace_mode: lua
+  color: "#fa1fa1"
   extensions:
   - .lua
   - .nse
@@ -541,16 +703,21 @@ Lua:
 Makefile:
   extensions:
   - .mak
+  - .mk
   filenames:
+  - makefile
   - Makefile
+  - GNUmakefile
 
 Mako:
   extensions:
+  - .mako
   - .mao
 
 Markdown:
   type: markup
   lexer: Text only
+  ace_mode: markdown
   primary_extension: .md
   extensions:
   - .markdown
@@ -561,6 +728,7 @@ Markdown:
 
 Matlab:
   type: programming
+  color: "#bb92ac"
   primary_extension: .matlab
   extensions:
   - .m
@@ -568,6 +736,7 @@ Matlab:
 
 Max/MSP:
   type: programming
+  color: "#ce279c"
   lexer: Text only
   extensions:
   - .mxt
@@ -580,6 +749,7 @@ Mirah:
   type: programming
   lexer: Ruby
   search_term: ruby
+  color: "#c7a938"
   extensions:
   - .duby
   - .mir
@@ -596,16 +766,21 @@ Myghty:
 
 Nemerle:
   type: programming
+  color: "#0d3c6e"
   extensions:
   - .n
 
 Nimrod:
+  type: programming
+  color: "#37775b"
   extensions:
   - .nim
+  - .nimrod
 
 Nu:
   type: programming
   lexer: Scheme
+  color: "#c9df40"
   aliases:
   - nush
   extensions:
@@ -623,6 +798,8 @@ NumPy:
 
 OCaml:
   type: programming
+  ace_mode: ocaml
+  color: "#3be133"
   primary_extension: .ml
   extensions:
   - .ml
@@ -638,6 +815,7 @@ ObjDump:
 
 Objective-C:
   type: programming
+  color: "#438eff"
   overrides:
   - .m
   primary_extension: .m
@@ -648,9 +826,15 @@ Objective-C:
 
 Objective-J:
   type: programming
+  color: "#ff0c5a"
   extensions:
   - .j
   - .sj
+
+Opa:
+  type: programming
+  extensions:
+  - .opa
 
 OpenCL:
   type: programming
@@ -659,8 +843,21 @@ OpenCL:
   extensions:
   - .cl
 
+OpenEdge ABL:
+  type: programming
+  aliases:
+  - progress
+  - openedge
+  - abl
+  primary_extension: .p
+  extensions:
+  - .cls
+  - .p
+
 PHP:
   type: programming
+  ace_mode: php
+  color: "#6e03c1"
   extensions:
   - .aw
   - .ctp
@@ -669,9 +866,12 @@ PHP:
   - .php4
   - .php5
   - .phpt
+  filenames:
+  - Phakefile
 
 Parrot:
   type: programming
+  color: "#f3ca0a"
   lexer: Text only
   primary_extension: .parrot # Dummy extension
 
@@ -695,39 +895,65 @@ Parrot Assembly:
 
 Perl:
   type: programming
+  ace_mode: perl
+  color: "#0298c3"
   overrides:
   - .pl
+  - .t
   primary_extension: .pl
   extensions:
   - .PL
   - .perl
   - .ph
   - .pl
+  - .plx
   - .pm
   - .pod
   - .psgi
   - .t
 
+PowerShell:
+  type: programming
+  ace_mode: powershell
+  aliases:
+  - posh
+  extensions:
+  - .ps1
+  - .psm1
+
 Prolog:
   type: programming
+  color: "#74283c"
   extensions:
   - .pl
   - .pro
   - .prolog
 
+Puppet:
+  type: programming
+  color: "#cc5555"
+  extensions:
+  - .pp
+  filenames:
+  - Modulefile
+
 Pure Data:
   type: programming
+  color: "#91de79"
   lexer: Text only
   extensions:
   - .pd
 
 Python:
   type: programming
+  ace_mode: python
+  color: "#3581ba"
   primary_extension: .py
   extensions:
   - .py
   - .pyw
   - .wsgi
+  - .xpy
 
 Python traceback:
   type: data
@@ -739,6 +965,7 @@ Python traceback:
 
 R:
   type: programming
+  color: "#198ce7"
   lexer: S
   overrides:
   - .r
@@ -756,6 +983,7 @@ RHTML:
 Racket:
   type: programming
   lexer: Scheme
+  color: "#ae17ff"
   primary_extension: .rkt
   extensions:
   - .rkt
@@ -773,6 +1001,7 @@ Raw token data:
 Rebol:
   type: programming
   lexer: REBOL
+  color: "#358a5b"
   extensions:
   - .r
   - .r2
@@ -785,6 +1014,8 @@ Redcode:
 
 Ruby:
   type: programming
+  ace_mode: ruby
+  color: "#701516"
   aliases:
   - jruby
   - macruby
@@ -797,6 +1028,7 @@ Ruby:
   - .gemspec
   - .god
   - .irbrc
+  - .podspec
   - .rake
   - .rb
   - .rbuild
@@ -807,31 +1039,40 @@ Ruby:
   - .watchr
   filenames:
   - Capfile
-  - Rakefile
-  - Thorfile
   - Gemfile
   - Guardfile
+  - Podfile
+  - Rakefile
+  - Thorfile
   - Vagrantfile
 
 Rust:
   type: programming
+  color: "#dea584"
   lexer: Text only
-  primary_extension: .rs
   extensions:
-  - .rc
   - .rs
 
 SCSS:
   type: markup
   group: CSS
+  ace_mode: scss
   extensions:
   - .scss
 
 SQL:
   type: data
+  ace_mode: sql
   searchable: false
   extensions:
   - .sql
+
+Sage:
+  type: programming
+  lexer: Python
+  group: Python
+  extensions:
+  - .sage
 
 Sass:
   type: markup
@@ -841,6 +1082,8 @@ Sass:
 
 Scala:
   type: programming
+  ace_mode: scala
+  color: "#7dd3b0"
   primary_extension: .scala
   extensions:
   - .sbt
@@ -848,6 +1091,7 @@ Scala:
 
 Scheme:
   type: programming
+  color: "#1e4aec"
   primary_extension: .scm
   extensions:
   - .scm
@@ -855,8 +1099,16 @@ Scheme:
   - .sps
   - .ss
 
+Scilab:
+  type: programming
+  primary_extension: .sci
+  extensions:
+  - .sce
+  - .tst
+
 Self:
   type: programming
+  color: "#0579aa"
   lexer: Text only
   extensions:
   - .self
@@ -865,6 +1117,7 @@ Shell:
   type: programming
   lexer: Bash
   search_term: bash
+  color: "#5861ce"
   aliases:
   - sh
   - bash
@@ -881,9 +1134,12 @@ Shell:
   - .zlogin
   - .zsh
   - .zshrc
+  - bashrc
+  - zshrc
 
 Smalltalk:
   type: programming
+  color: "#596706"
   extensions:
   - .st
 
@@ -893,7 +1149,7 @@ Smarty:
 
 Standard ML:
   type: programming
-  lexer: Standard ML
+  color: "#dc566d"
   aliases:
   - sml
   primary_extension: .sml
@@ -903,12 +1159,14 @@ Standard ML:
 
 SuperCollider:
   type: programming
+  color: "#46390b"
   lexer: Text only
   extensions:
   - .sc
 
 Tcl:
   type: programming
+  color: "#e4cc98"
   extensions:
   - .tcl
 
@@ -922,25 +1180,46 @@ Tcsh:
 
 TeX:
   type: markup
+  ace_mode: latex
   primary_extension: .tex
+  overrides:
+  - .cls
   extensions:
   - .aux
   - .cls
+  - .dtx
+  - .ins
+  - .ltx
   - .sty
   - .tex
   - .toc
 
+Tea:
+  type: markup
+  extensions:
+  - .tea
+
 Text:
   type: data
   lexer: Text only
+  ace_mode: text
   extensions:
   - .txt
 
 Textile:
   type: markup
   lexer: Text only
+  ace_mode: textile
   extensions:
   - .textile
+
+Turing:
+  type: programming
+  color: "#45f715"
+  lexer: Text only
+  extensions:
+  - .t
+  - .tu
 
 Twig:
   type: markup
@@ -951,25 +1230,31 @@ Twig:
 
 VHDL:
   type: programming
-  lexer: Text only
-  primary_extension: .vhd
+  lexer: vhdl
+  color: "#543978"
   extensions:
   - .vhd
   - .vhdl
 
 Vala:
   type: programming
+  color: "#ee7d06"
   extensions:
   - .vala
+  - .vapi
 
 Verilog:
   type: programming
-  lexer: verilog
+  lexer: Verilog
+  color: "#848bf3"
+  overrides:
+  - .v
   extensions:
   - .v
 
 VimL:
   type: programming
+  color: "#199c4b"
   search_term: vim
   aliases:
   - vim
@@ -978,10 +1263,13 @@ VimL:
   filenames:
   - .gvimrc
   - .vimrc
+  - vimrc
+  - gvimrc
 
 Visual Basic:
   type: programming
   lexer: VB.net
+  color: "#945db7"
   primary_extension: .vb
   extensions:
   - .bas
@@ -992,6 +1280,7 @@ Visual Basic:
 
 XML:
   type: markup
+  ace_mode: xml
   primary_extension: .xml
   extensions:
   - .glade
@@ -1006,6 +1295,8 @@ XML:
   - .wxl
   - .wxs
   - .xaml
+  - .xlf
+  - .xliff
   - .xml
   - .xsd
   - .xsl
@@ -1016,6 +1307,7 @@ XML:
 
 XQuery:
   type: programming
+  color: "#2700e2"
   extensions:
   - .xq
   - .xqm
@@ -1036,6 +1328,14 @@ YAML:
   filenames:
   - .gemrc
 
+eC:
+  type: programming
+  search_term: ec
+  primary_extension: .ec
+  extensions:
+  - .ec
+  - .eh
+
 mupad:
   lexer: MuPAD
   extensions:
@@ -1044,6 +1344,7 @@ mupad:
 ooc:
   type: programming
   lexer: Ooc
+  color: "#b0b77e"
   extensions:
   - .ooc
 

--- a/test/test_language.rb
+++ b/test/test_language.rb
@@ -14,7 +14,12 @@ class TestLanguage < Test::Unit::TestCase
 
   include LanguageSniffer
 
+
+
   def test_ambiguous_extensions
+    assert Language.ambiguous?('.cls')
+    assert_equal Language['TeX'], Language.find_by_extension('cls')
+
     assert Language.ambiguous?('.h')
     assert_equal Language['C'], Language.find_by_extension('h')
 
@@ -26,6 +31,12 @@ class TestLanguage < Test::Unit::TestCase
 
     assert Language.ambiguous?('.r')
     assert_equal Language['R'], Language.find_by_extension('r')
+
+    assert Language.ambiguous?('.t')
+    assert_equal Language['Perl'], Language.find_by_extension('t')
+
+    assert Language.ambiguous?('.v')
+    assert_equal Language['Verilog'], Language.find_by_extension('v')
   end
 
   def test_lexer
@@ -37,23 +48,25 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['C'], Language['XS'].lexer
     assert_equal Lexer['C++'], Language['C++'].lexer
     assert_equal Lexer['Coldfusion HTML'], Language['ColdFusion'].lexer
+    assert_equal Lexer['Coq'], Language['Coq'].lexer
+    assert_equal Lexer['FSharp'], Language['F#'].lexer
+    assert_equal Lexer['FSharp'], Language['F#'].lexer
     assert_equal Lexer['Fortran'], Language['FORTRAN'].lexer
     assert_equal Lexer['Gherkin'], Language['Cucumber'].lexer
+    assert_equal Lexer['Groovy'], Language['Groovy'].lexer
     assert_equal Lexer['HTML'], Language['HTML'].lexer
     assert_equal Lexer['HTML+Django/Jinja'], Language['HTML+Django'].lexer
     assert_equal Lexer['HTML+PHP'], Language['HTML+PHP'].lexer
+    assert_equal Lexer['JSON'], Language['JSON'].lexer
     assert_equal Lexer['Java'], Language['ChucK'].lexer
-    assert_equal Lexer['Java'], Language['Groovy'].lexer
     assert_equal Lexer['Java'], Language['Java'].lexer
-    assert_equal Lexer['JavaScript'], Language['JSON'].lexer
     assert_equal Lexer['JavaScript'], Language['JavaScript'].lexer
     assert_equal Lexer['MOOCode'], Language['Moocode'].lexer
     assert_equal Lexer['MuPAD'], Language['mupad'].lexer
     assert_equal Lexer['NASM'], Language['Assembly'].lexer
-    assert_equal Lexer['OCaml'], Language['F#'].lexer
     assert_equal Lexer['OCaml'], Language['OCaml'].lexer
-    assert_equal Lexer['Standard ML'], Language['Standard ML'].lexer
     assert_equal Lexer['Ooc'], Language['ooc'].lexer
+    assert_equal Lexer['OpenEdge ABL'], Language['OpenEdge ABL'].lexer
     assert_equal Lexer['REBOL'], Language['Rebol'].lexer
     assert_equal Lexer['RHTML'], Language['HTML+ERB'].lexer
     assert_equal Lexer['RHTML'], Language['RHTML'].lexer
@@ -64,8 +77,10 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Lexer['Scheme'], Language['Nu'].lexer
     assert_equal Lexer['Scheme'], Language['Racket'].lexer
     assert_equal Lexer['Scheme'], Language['Scheme'].lexer
+    assert_equal Lexer['Standard ML'], Language['Standard ML'].lexer
     assert_equal Lexer['TeX'], Language['TeX'].lexer
     assert_equal Lexer['Text only'], Language['Text'].lexer
+    assert_equal Lexer['Verilog'], Language['Verilog'].lexer
     assert_equal Lexer['aspx-vb'], Language['ASP'].lexer
     assert_equal Lexer['haXe'], Language['HaXe'].lexer
     assert_equal Lexer['reStructuredText'], Language['reStructuredText'].lexer
@@ -83,11 +98,14 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['C'], Language.find_by_alias('c')
     assert_equal Language['C++'], Language.find_by_alias('c++')
     assert_equal Language['C++'], Language.find_by_alias('cpp')
+    assert_equal Language['CoffeeScript'], Language.find_by_alias('coffee')
     assert_equal Language['ColdFusion'], Language.find_by_alias('cfm')
     assert_equal Language['Common Lisp'], Language.find_by_alias('common-lisp')
     assert_equal Language['Common Lisp'], Language.find_by_alias('lisp')
     assert_equal Language['Darcs Patch'], Language.find_by_alias('dpatch')
+    assert_equal Language['Dart'], Language.find_by_alias('dart')
     assert_equal Language['Emacs Lisp'], Language.find_by_alias('elisp')
+    assert_equal Language['Emacs Lisp'], Language.find_by_alias('emacs')
     assert_equal Language['Emacs Lisp'], Language.find_by_alias('emacs-lisp')
     assert_equal Language['Gettext Catalog'], Language.find_by_alias('pot')
     assert_equal Language['HTML'], Language.find_by_alias('html')
@@ -100,7 +118,12 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['JavaScript'], Language.find_by_alias('js')
     assert_equal Language['Literate Haskell'], Language.find_by_alias('lhs')
     assert_equal Language['Literate Haskell'], Language.find_by_alias('literate-haskell')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_alias('openedge')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_alias('progress')
+    assert_equal Language['OpenEdge ABL'], Language.find_by_alias('abl')
     assert_equal Language['Parrot Internal Representation'], Language.find_by_alias('pir')
+    assert_equal Language['PowerShell'], Language.find_by_alias('posh')
+    assert_equal Language['Puppet'], Language.find_by_alias('puppet')
     assert_equal Language['Pure Data'], Language.find_by_alias('pure-data')
     assert_equal Language['Raw token data'], Language.find_by_alias('raw')
     assert_equal Language['Ruby'], Language.find_by_alias('rb')
@@ -149,6 +172,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal 'common-lisp', Language['Common Lisp'].search_term
     assert_equal 'html+erb',    Language['HTML+ERB'].search_term
     assert_equal 'max/msp',     Language['Max/MSP'].search_term
+    assert_equal 'puppet',      Language['Puppet'].search_term
     assert_equal 'pure-data',   Language['Pure Data'].search_term
 
     assert_equal 'aspx-vb',       Language['ASP'].search_term
@@ -174,6 +198,7 @@ class TestLanguage < Test::Unit::TestCase
   def test_programming
     assert_equal :programming, Language['JavaScript'].type
     assert_equal :programming, Language['Perl'].type
+    assert_equal :programming, Language['PowerShell'].type
     assert_equal :programming, Language['Python'].type
     assert_equal :programming, Language['Ruby'].type
   end
@@ -212,6 +237,7 @@ class TestLanguage < Test::Unit::TestCase
   def test_find_by_extension
     assert_equal Language['Ruby'], Language.find_by_extension('.rb')
     assert_equal Language['Ruby'], Language.find_by_extension('rb')
+    assert_equal Language['Dart'], Language.find_by_extension('dart')
     assert_equal Language['Groff'], Language.find_by_extension('man')
     assert_equal Language['Groff'], Language.find_by_extension('1')
     assert_equal Language['Groff'], Language.find_by_extension('2')
@@ -220,7 +246,9 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['PHP'], Language.find_by_extension('php3')
     assert_equal Language['PHP'], Language.find_by_extension('php4')
     assert_equal Language['PHP'], Language.find_by_extension('php5')
-    assert_nil Language.find_by_extension('.kt')
+    assert_equal Language['PowerShell'], Language.find_by_extension('psm1')
+    assert_equal Language['PowerShell'], Language.find_by_extension('ps1')
+    assert_nil Language.find_by_extension('.nkt')
   end
 
   def test_find_all_by_extension
@@ -239,7 +267,7 @@ class TestLanguage < Test::Unit::TestCase
     assert_equal Language['Ruby'], Language.find_by_filename('Rakefile')
     assert_nil Language.find_by_filename('rb')
     assert_nil Language.find_by_filename('.rb')
-    assert_nil Language.find_by_filename('.kt')
+    assert_nil Language.find_by_filename('.nkt')
   end
 
   def test_find

--- a/test/test_pathname.rb
+++ b/test/test_pathname.rb
@@ -4,7 +4,7 @@ require 'test/unit'
 
 class TestPathname < Test::Unit::TestCase
   include LanguageSniffer
-
+  
   def test_to_s
     assert_equal "file.rb", Pathname.new("file.rb").to_s
   end
@@ -38,6 +38,6 @@ class TestPathname < Test::Unit::TestCase
     assert_equal Language['Python'], Pathname.new("itty.py").language
     assert_equal Language['Nu'], Pathname.new("itty.nu").language
 
-    assert_nil Pathname.new("defun.kt").language
+    assert_nil Pathname.new("defu.nkt").language
   end
 end


### PR DESCRIPTION
Hey there. I went and updated the list of languages here, pulled (and very slightly slightly modified (removed `color:` lines and fixed a capitalization typo that was causing a test to fail)) from the upstream Linguist project.

I also updated some of the test files to match upstream, minus some of the new functionality that they added (like color and mimetype).

My test output is the same as when I run it on master from your repository (which is one error: a UTF-8 related error). Everything else passes:

```
39 tests, 1658 assertions, 0 failures, 1 errors, 0 skips
```

Any interest in this?
