### PR TITLE
Update Gemfile source

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source :rubygems
+source "http://rubygems.org"
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -1,2 +1,2 @@
-source "http://rubygems.org"
+source "https://rubygems.org"
 gemspec


### PR DESCRIPTION
Due to the security vulnerabilities with Rubygems.org, Bundler recommends using the URL 'http://rubygems.org' over the symbol `:rubygems` in the Gemfile.
